### PR TITLE
Implement Kubernetes-inspired styling

### DIFF
--- a/_includes/default/css-include.html
+++ b/_includes/default/css-include.html
@@ -38,3 +38,5 @@
 {% endif -%}
 
 <link href="{{ site.baseurl }}/assets/css/nav-media.css" rel="stylesheet">
+
+<link href="{{ site.baseurl }}/assets/css/k8s-style.css" rel="stylesheet">

--- a/assets/_scss/colors/dark-colors.scss
+++ b/assets/_scss/colors/dark-colors.scss
@@ -7,14 +7,14 @@
 // otherwise it will be added to all output css files
 
 // dark color scheme definitions
-$brand-color-dark: #71b2ff;
+$brand-color-dark: #5AA5F9;
 $main-background-dark: #191919;
 $button-color-dark: #666;
 $menu-background-dark: #252525;
 $header-color-dark: #c0c0c0;
 $container-background-dark: #2a2a2a;
 $hr-color-dark: #333;
-$anchor-text-color-dark: #3389de;
+$anchor-text-color-dark: #5AA5F9;
 
 // layout: default
 // default/body-main-styles

--- a/assets/_scss/colors/light-colors.scss
+++ b/assets/_scss/colors/light-colors.scss
@@ -7,14 +7,14 @@
 // otherwise it will be added to all output css files
 
 // light color scheme definitions
-$brand-color-light: #416289;
+$brand-color-light: #326CE5;
 $main-background-light: #efefef;
 $button-color-light: #a19e9e;
-$menu-background-light: #f9f9f9;
+$menu-background-light: #f7f7f7;
 $header-color-light: #5f5e5e;
 $container-background-light: #fff;
 $hr-color-light: #eee;
-$anchor-text-color-light: #3389de;
+$anchor-text-color-light: #326CE5;
 
 // layout: default
 // default/body-main-styles

--- a/assets/css/k8s-style.css
+++ b/assets/css/k8s-style.css
@@ -1,0 +1,17 @@
+/* Kubernetes-inspired custom styles */
+.top-nav {
+  background-color: #326CE5;
+}
+.top-nav .navbar-brand,
+.top-nav .nav>li>a,
+.top-nav .navbar-toggle {
+  color: #fff;
+}
+.top-nav .nav>li>a:hover,
+.top-nav .navbar-brand:hover {
+  color: #fff;
+  text-decoration: underline;
+}
+#side-nav-container {
+  background-color: #f7f7f7;
+}


### PR DESCRIPTION
## Summary
- add custom stylesheet with Kubernetes-inspired colors
- link new stylesheet in main layout
- update light and dark color variables to use Kubernetes blue tones

## Testing
- `bundle install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6846ecec8a688331897cf3ad98496777