### PR TITLE
Add simple documentation platform with sample docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,23 @@
-# Simple Node.js Server
+# Documentation Platform
 
-This is a minimal Node.js application that starts an HTTP server.
+This project is a simple Node.js application that serves a small documentation platform without any external dependencies.
+
+## Features
+
+- Lists documentation files stored in the `docs/` directory.
+- View individual documents.
+- Upload new documents via a basic HTML form.
 
 ## Usage
 
-Run the server with:
+1. Ensure you have Node.js installed.
+2. Run the server with:
 
 ```bash
 node index.js
 ```
 
-The server listens on port `3000` and responds with `Hello World`.
+3. Open `http://localhost:3000` in your browser to see the list of documents.
+4. Click **Upload New Document** to add more documentation.
+
+Ten example documents covering various technology topics are included in the `docs/` directory.

--- a/docs/doc1.md
+++ b/docs/doc1.md
@@ -1,0 +1,10 @@
+# Using the Documentation Platform
+
+This guide explains how to use the platform:
+
+1. Visit the home page to see available documents.
+2. Click a document title to read it.
+3. Go to the Upload page to add a new document.
+4. Enter a name and content, then submit.
+
+Enjoy sharing your knowledge!

--- a/docs/doc10.md
+++ b/docs/doc10.md
@@ -1,0 +1,3 @@
+# Database Overview
+
+Databases store and manage data for your applications. Examples include MySQL and MongoDB.

--- a/docs/doc2.md
+++ b/docs/doc2.md
@@ -1,0 +1,3 @@
+# Introduction to Node.js
+
+Node.js is a JavaScript runtime built on Chrome's V8 engine. It allows you to run JavaScript on the server.

--- a/docs/doc3.md
+++ b/docs/doc3.md
@@ -1,0 +1,3 @@
+# Basics of HTML
+
+HTML is the standard markup language for creating web pages.

--- a/docs/doc4.md
+++ b/docs/doc4.md
@@ -1,0 +1,3 @@
+# CSS Tips
+
+CSS allows you to style your HTML content. Use classes and ids to target elements effectively.

--- a/docs/doc5.md
+++ b/docs/doc5.md
@@ -1,0 +1,3 @@
+# JavaScript ES6 Features
+
+ES6 introduced features like arrow functions, classes, and template literals.

--- a/docs/doc6.md
+++ b/docs/doc6.md
@@ -1,0 +1,3 @@
+# Express.js Quickstart
+
+Express.js is a minimal web framework for Node.js that simplifies routing and middleware.

--- a/docs/doc7.md
+++ b/docs/doc7.md
@@ -1,0 +1,3 @@
+# Git Workflow
+
+Git is a version control system that helps manage changes in your codebase.

--- a/docs/doc8.md
+++ b/docs/doc8.md
@@ -1,0 +1,3 @@
+# Docker Basics
+
+Docker lets you package applications into containers for consistent environments.

--- a/docs/doc9.md
+++ b/docs/doc9.md
@@ -1,0 +1,3 @@
+# REST API Design
+
+A REST API uses HTTP methods and URIs to access resources in a stateless way.

--- a/index.js
+++ b/index.js
@@ -1,12 +1,114 @@
 const http = require('http');
+const fs = require('fs');
+const path = require('path');
 
 const hostname = '0.0.0.0';
 const port = 3000;
+const docsDir = path.join(__dirname, 'docs');
+
+function send(res, status, content, type = 'text/html') {
+  res.statusCode = status;
+  res.setHeader('Content-Type', type);
+  res.end(content);
+}
+
+function listDocs() {
+  if (!fs.existsSync(docsDir)) return [];
+  return fs.readdirSync(docsDir).filter(f => f.endsWith('.md'));
+}
+
+function handleIndex(req, res) {
+  const docs = listDocs();
+  const docLinks = docs.map(d => `<li><a href="/docs/${encodeURIComponent(d)}">${d}</a></li>`).join('\n');
+  const html = `<!DOCTYPE html>
+<html><head><title>Documentation</title></head><body>
+<h1>Documentation</h1>
+<ul>${docLinks}</ul>
+<a href="/upload">Upload New Document</a>
+</body></html>`;
+  send(res, 200, html);
+}
+
+function handleDoc(req, res, name) {
+  const filePath = path.join(docsDir, name);
+  if (fs.existsSync(filePath)) {
+    const content = fs.readFileSync(filePath);
+    send(res, 200, content, 'text/plain');
+  } else {
+    send(res, 404, 'Document not found');
+  }
+}
+
+function handleUploadPage(req, res) {
+  const html = `<!DOCTYPE html>
+<html><head><title>Upload</title></head><body>
+<h1>Upload Document</h1>
+<form method="POST" action="/upload">
+<label>Document Name: <input name="name"/></label><br/>
+<label>Content:</label><br/>
+<textarea name="content" rows="10" cols="50"></textarea><br/>
+<button type="submit">Upload</button>
+</form>
+<a href="/">Back</a>
+</body></html>`;
+  send(res, 200, html);
+}
+
+function parseBody(req, callback) {
+  let body = '';
+  req.on('data', chunk => {
+    body += chunk;
+  });
+  req.on('end', () => {
+    const parsed = {};
+    body.split('&').forEach(pair => {
+      const [key, value] = pair.split('=');
+      if (key) parsed[decodeURIComponent(key)] = decodeURIComponent((value || '').replace(/\+/g, ' '));
+    });
+    callback(parsed);
+  });
+}
+
+function handleUpload(req, res) {
+  parseBody(req, data => {
+    const name = data.name;
+    const content = data.content || '';
+    if (!name) {
+      send(res, 400, 'Name required');
+      return;
+    }
+    const fileName = name.endsWith('.md') ? name : `${name}.md`;
+    const filePath = path.join(docsDir, fileName);
+    fs.writeFileSync(filePath, content);
+    res.statusCode = 302;
+    res.setHeader('Location', '/');
+    res.end();
+  });
+}
 
 const server = http.createServer((req, res) => {
-  res.statusCode = 200;
-  res.setHeader('Content-Type', 'text/plain');
-  res.end('Hello World\n');
+  if (req.method === 'GET' && req.url === '/') {
+    handleIndex(req, res);
+    return;
+  }
+
+  if (req.method === 'GET' && req.url.startsWith('/docs/')) {
+    const name = decodeURIComponent(req.url.substring('/docs/'.length));
+    handleDoc(req, res, name);
+    return;
+  }
+
+  if (req.method === 'GET' && req.url === '/upload') {
+    handleUploadPage(req, res);
+    return;
+  }
+
+  if (req.method === 'POST' && req.url === '/upload') {
+    handleUpload(req, res);
+    return;
+  }
+
+  send(res, 404, 'Not Found');
 });
 
 server.listen(port, hostname, () => {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "g3lson.github.io",
+  "version": "1.0.0",
+  "description": "This is a minimal Node.js application that starts an HTTP server.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- turn simple server into minimal documentation platform
- create HTML interface for listing, viewing, and uploading docs
- add 10 example technology-related documents
- update README with usage instructions
- add package.json for completeness

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6846f27a4a208331a855aac7aaba1c40